### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Sensors
 
 New Relic integration pack comes with a sensor which watches for alerts which

--- a/actions/get_alerts.yaml
+++ b/actions/get_alerts.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_alerts"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get alerts for app."
   enabled: true
   entry_point: "get_alerts.py"

--- a/actions/get_metric_data.yaml
+++ b/actions/get_metric_data.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_metric_data"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get metric data for metric."
   enabled: true
   entry_point: "get_metric_data.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - monitoring
   - app monitoring
   - application level monitoring
-version : 0.3.0
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.